### PR TITLE
Generate facts for node children

### DIFF
--- a/treeedb/src/cli.rs
+++ b/treeedb/src/cli.rs
@@ -77,7 +77,11 @@ fn stdin_string() -> Result<String> {
 
 pub fn main(language: tree_sitter::Language) -> Result<()> {
     let args = Args::parse();
-    let mut fc = super::wide::WideCsvConsumer::new("node.csv".into(), "field.csv".into())?;
+    let mut fc = super::wide::WideCsvConsumer::new(
+        "node.csv".into(),
+        "field.csv".into(),
+        "child.csv".into(),
+    )?;
     if args.source_files.is_empty() {
         let content = stdin_string()?;
         let tree = parse(language, &content)?;

--- a/treeedb/src/consumer.rs
+++ b/treeedb/src/consumer.rs
@@ -22,5 +22,7 @@ pub trait FactConsumer {
         child: &Node<'_>,
     ) -> Result<(), Self::Err>;
 
+    fn child(&mut self, parent: &Node<'_>, child: &Node<'_>) -> Result<(), Self::Err>;
+
     fn node(&mut self, node: &Node<'_>, source: &[u8]) -> Result<(), Self::Err>;
 }

--- a/treeedb/src/lib.rs
+++ b/treeedb/src/lib.rs
@@ -22,6 +22,7 @@ pub fn facts<E>(
             }
         }
         for child in node.named_children(&mut cursor) {
+            fc.child(&node, &child)?;
             nodes.push(child);
         }
     }

--- a/treeedb/src/narrow.rs
+++ b/treeedb/src/narrow.rs
@@ -35,6 +35,10 @@ impl FactConsumer for NarrowCsvConsumer {
         Ok(())
     }
 
+    fn child(&mut self, _parent: &Node<'_>, _child: &Node<'_>) -> Result<(), Self::Err> {
+        Ok(())
+    }
+
     fn node(&mut self, node: &Node<'_>, _source: &[u8]) -> Result<(), Self::Err> {
         let id = node.id();
         self.node_id

--- a/treeedb/src/wide.rs
+++ b/treeedb/src/wide.rs
@@ -10,13 +10,19 @@ use super::consumer::FactConsumer;
 pub struct WideCsvConsumer {
     node: csv::Writer<File>,
     field: csv::Writer<File>,
+    child: csv::Writer<File>,
 }
 
 impl WideCsvConsumer {
-    pub fn new(node_file_path: PathBuf, field_file_path: PathBuf) -> Result<Self, io::Error> {
+    pub fn new(
+        node_file_path: PathBuf,
+        field_file_path: PathBuf,
+        child_file_path: PathBuf,
+    ) -> Result<Self, io::Error> {
         Ok(WideCsvConsumer {
             node: csv::Writer::from_writer(File::create(node_file_path)?),
             field: csv::Writer::from_writer(File::create(field_file_path)?),
+            child: csv::Writer::from_writer(File::create(child_file_path)?),
         })
     }
 }
@@ -32,6 +38,12 @@ impl FactConsumer for WideCsvConsumer {
     ) -> Result<(), Self::Err> {
         self.field
             .write_record([&parent.id().to_string(), name, &child.id().to_string()])?;
+        Ok(())
+    }
+
+    fn child(&mut self, parent: &Node<'_>, child: &Node<'_>) -> Result<(), Self::Err> {
+        self.child
+            .write_record([&parent.id().to_string(), &child.id().to_string()])?;
         Ok(())
     }
 

--- a/treeedbgen/src/lib.rs
+++ b/treeedbgen/src/lib.rs
@@ -12,6 +12,8 @@ pub struct Node {
     pub fields: HashMap<String, Field>,
     #[serde(default)] // empty
     pub subtypes: Vec<Subtype>,
+    #[serde(default)] // empty
+    pub children: Option<Field>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Following #42, this PR attempts to add fact generation for child nodes. It adds a `child.csv`, which stores a `parent, child` relation. It also generates `_c` relations, analogous to the `_f` relations for fields.

Interested in your thoughts!