### PR TITLE
Added suffix '_literal' to boolean literals

### DIFF
--- a/treeedb/src/cli.rs
+++ b/treeedb/src/cli.rs
@@ -32,10 +32,10 @@ fn handle_parse_errors(path: &str, tree: &Tree, on_parse_error: &OnParseError) {
         OnParseError::Warn if !node.has_error() => (),
         OnParseError::Error if !node.has_error() => (),
         OnParseError::Warn => {
-            eprintln!("[warn] Parse error in {}", path);
+            eprintln!("[warn] Parse error in {path}");
         }
         OnParseError::Error => {
-            eprintln!("[error] Parse error in {}", path);
+            eprintln!("[error] Parse error in {path}");
             process::exit(1);
         }
     }
@@ -58,7 +58,7 @@ pub struct Args {
 }
 
 fn read_file(file: &str) -> Result<String> {
-    fs::read_to_string(file).with_context(|| format!("Failed to read file {}", file))
+    fs::read_to_string(file).with_context(|| format!("Failed to read file {file}"))
 }
 
 fn parse(language: tree_sitter::Language, code: &str) -> Result<Tree> {

--- a/treeedbgen-souffle/src/cli.rs
+++ b/treeedbgen-souffle/src/cli.rs
@@ -26,7 +26,7 @@ pub fn main(node_types: &str) -> Result<()> {
     };
     if let Some(path) = args.output {
         let mut file = std::fs::File::create(&path)
-            .with_context(|| format!("Failed to write to file {}", path))?;
+            .with_context(|| format!("Failed to write to file {path}"))?;
         super::r#gen(&config, &mut file, node_types)?;
     } else {
         // https://nnethercote.github.io/perf-book/io.html#locking

--- a/treeedbgen-souffle/src/gen.rs
+++ b/treeedbgen-souffle/src/gen.rs
@@ -17,8 +17,9 @@ fn node_with_fields(
     node: &Node,
 ) -> Result<String, io::Error> {
     let rel_name = match node.ty.as_str() {
-    "true" | "false" => format!("{}_literal", node.ty),
-    _ => node.ty.clone(),
+        "true" => "true_literal",
+        "false" => "false_literal",
+        _ => &node.ty,
     };
     let type_name = node.ty.to_upper_camel_case();
     writeln!(w, ".type {}{} <: symbol", config.type_prefix, type_name)?;

--- a/treeedbgen-souffle/src/gen.rs
+++ b/treeedbgen-souffle/src/gen.rs
@@ -16,7 +16,10 @@ fn node_with_fields(
     w: &mut impl Write,
     node: &Node,
 ) -> Result<String, io::Error> {
-    let rel_name = &node.ty;
+    let rel_name = match node.ty.as_str() {
+    "true" | "false" => format!("{}_literal", node.ty),
+    _ => node.ty.clone(),
+    };
     let type_name = node.ty.to_upper_camel_case();
     writeln!(w, ".type {}{} <: symbol", config.type_prefix, type_name)?;
     writeln!(

--- a/treeedbgen-souffle/src/gen.rs
+++ b/treeedbgen-souffle/src/gen.rs
@@ -59,7 +59,7 @@ fn node_with_fields(
                 node.ty.to_upper_camel_case(),
                 field_name.to_upper_camel_case(),
             );
-            write!(w, ".type {} = ", field_type_name)?;
+            write!(w, ".type {field_type_name} = ")?;
             let mut types = Vec::new();
             for t in &field.types {
                 if t.named {
@@ -193,7 +193,7 @@ impl PrivGenConfig {
         PrivGenConfig {
             printsize: config.printsize,
             relation_prefix: if let Some(pfx) = &config.prefix {
-                format!("{}_", pfx)
+                format!("{pfx}_")
             } else {
                 "".to_owned()
             },


### PR DESCRIPTION
This PR aim to fix the bug mentioned in https://github.com/langston-barrett/treeedb/issues/195, where souffle throws the following error, when compiling the generated datalog file:
Error: syntax error, unexpected false literal constraint, expecting identifier in file treeedb-c.dl at line 955
.decl false(x: False)

New generated relations:
.type False <: symbol
.decl false_literal(x: False)
false_literal(as(x, False)) :- node(x, "false", _, _, _, _, _, _, _, _, _, _, _).


.type True <: symbol
.decl true_literal(x: True)
true_literal(as(x, True)) :- node(x, "true", _, _, _, _, _, _, _, _, _, _, _).